### PR TITLE
fix: remove persistence from named volume frontend-dist:/srv

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,7 +10,7 @@ RUN npm run build
 FROM busybox:latest
 
 WORKDIR /srv
-COPY --from=build /app/dist /srv/
+COPY --from=build /app/dist /app-dist
 
 COPY --chmod=755 docker-entrypoint.sh /docker-entrypoint.sh
 

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -6,6 +6,8 @@ sed \
   s|$STRICT_USER_FIELDS|'${STRICT_USER_FIELDS}'|g; \
   s|$REQUIRE_EMAIL|'${REQUIRE_EMAIL}'|g; \
   s|$DEMO|'${DEMO}'|g' \
- /srv/runtime-config.template.js > /srv/runtime-config.js
+ /app-dist/runtime-config.template.js > /app-dist/runtime-config.js
+
+rm -rf /srv/* && cp -r /app-dist/* /srv/
 
 exec "$@"


### PR DESCRIPTION
The persistence of frontend-dist:/srv caused the frontend's files to be frozen on the first build. Subsequent builds caused no changes without clearing the volume.

Decided to handle it in the `docker-entrypoint.sh`, as it's the cleanest way and doesn't need extra steps in docker-compose.